### PR TITLE
8.1: Use runner with uid 1001 to match GA runner.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:8-alpine
 
+ARG RUNNER_UID=1001
+
 LABEL maintainer="marji@morpht.com"
 LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php"
 
@@ -20,5 +22,6 @@ RUN apk add --no-cache --update git \
     && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer
 
-# Remove warning about running as root in composer
-ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN adduser -D -h /home/runner -u $RUNNER_UID runner
+
+USER runner


### PR DESCRIPTION
Updating the 8.1 branch.

We don't need to run as root. Use user `runner` with the same uid as the official GA runner does.

This will also solve the git ownership mismatch - safe directory, no more of this error:

    detected dubious ownership in repository at '/__w/xxx/xxx'
    To add an exception for this directory, call:
       git config --global --add safe.directory /__w/xxx/xxx