### PR TITLE
PHP 8.2 version: Use php:8.2.14-alpine3.18 image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-alpine
+FROM php:8.2.14-alpine3.18
 
 ARG RUNNER_UID=1001
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ci-php
 
-Docker image based on the official dockerhub image php:8-alpine
+Docker image based on the official dockerhub image php:8.2.x-alpine3.18
 
 A few modifications:
 


### PR DESCRIPTION
First version of a php 8.2 image. 

Starting with current php 8.2.14 and Alpine 3.18 which is supported till 2025-05-09.