### PR TITLE
PHP 8.1 version: Use php:8.1.27-alpine3.18 image, composer 2.6.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.27-alpine3.17
+FROM php:8.1.27-alpine3.18
 
 ARG RUNNER_UID=1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:8-alpine
 
+ARG RUNNER_UID=1001
+
 LABEL maintainer="marji@morpht.com"
 LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php"
 
@@ -20,5 +22,6 @@ RUN apk add --no-cache --update git \
     && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer
 
-# Remove warning about running as root in composer
-ENV COMPOSER_ALLOW_SUPERUSER=1
+RUN adduser -D -h /home/runner -u $RUNNER_UID runner
+
+USER runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG RUNNER_UID=1001
 LABEL maintainer="marji@morpht.com"
 LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php"
 
-ENV COMPOSER_VERSION=2.6.4 \
-  COMPOSER_HASH_SHA256=5a39f3e2ce5ba391ee3fecb227faf21390f5b7ed5c56f14cab9e1c3048bcf8b8
+ENV COMPOSER_VERSION=2.6.6 \
+  COMPOSER_HASH_SHA256=72600201c73c7c4b218f1c0511b36d8537963e36aafa244757f52309f885b314
 
 RUN apk add --no-cache --update git \
         bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG RUNNER_UID=1001
 LABEL maintainer="marji@morpht.com"
 LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php"
 
-ENV COMPOSER_VERSION=2.5.7 \
-  COMPOSER_HASH_SHA256=9256c4c1c803b9d0cb7a66a1ab6c737e48c43cc6df7b8ec9ec2497a724bf44de
+ENV COMPOSER_VERSION=2.6.4 \
+  COMPOSER_HASH_SHA256=5a39f3e2ce5ba391ee3fecb227faf21390f5b7ed5c56f14cab9e1c3048bcf8b8
 
 RUN apk add --no-cache --update git \
         bash \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Docker image based on the official dockerhub image php:8-alpine
 
 A few modifications:
 
-- added composer v2.5.x
+- added composer v2.6.x
 - installed several packages, e.g. git and mysql-client
 - added php extensions - gd, pdo_mysql, zip
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ci-php
 
-Docker image based on the official dockerhub image php:8.1.x-alpine3.17
+Docker image based on the official dockerhub image php:8.1.x-alpine3.18
 
 A few modifications:
 


### PR DESCRIPTION
Bumping PHP version to 8.1.27 and composer to 2.6.6.
Need to use Alpine 3.18 as upstream php 8.1.27 image is not available (hasn't been built) on Alpine 3.17