### PR TITLE
Allow to specify PHP memory_limit (128M default).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php"
 
 ENV COMPOSER_VERSION=2.6.6 \
     COMPOSER_HASH_SHA256=72600201c73c7c4b218f1c0511b36d8537963e36aafa244757f52309f885b314 \
-    PHP_MEMORY_LIMIT=512M
+    PHP_MEMORY_LIMIT=128M
 
 RUN apk add --no-cache --update git \
         bash \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,7 @@ RUN apk add --no-cache --update git \
 
 RUN adduser -D -h /home/runner -u $RUNNER_UID runner
 
-USER runner
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ LABEL maintainer="marji@morpht.com"
 LABEL org.opencontainers.image.source="https://github.com/morpht/ci-php"
 
 ENV COMPOSER_VERSION=2.6.6 \
-  COMPOSER_HASH_SHA256=72600201c73c7c4b218f1c0511b36d8537963e36aafa244757f52309f885b314
+    COMPOSER_HASH_SHA256=72600201c73c7c4b218f1c0511b36d8537963e36aafa244757f52309f885b314 \
+    PHP_MEMORY_LIMIT=512M
 
 RUN apk add --no-cache --update git \
         bash \
@@ -20,11 +21,9 @@ RUN apk add --no-cache --update git \
     && rm -rf /var/cache/apk/* \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \
     && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
-    && chmod +x /usr/local/bin/composer
+    && chmod +x /usr/local/bin/composer \
+    && echo "memory_limit = ${PHP_MEMORY_LIMIT}" > /usr/local/etc/php/conf.d/memory-limit.ini
 
 RUN adduser -D -h /home/runner -u $RUNNER_UID runner
 
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
-
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+USER runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add --no-cache --update git \
     && curl -L -o /usr/local/bin/composer https://github.com/composer/composer/releases/download/${COMPOSER_VERSION}/composer.phar \
     && echo "$COMPOSER_HASH_SHA256  /usr/local/bin/composer" | sha256sum -c \
     && chmod +x /usr/local/bin/composer \
-    && echo "memory_limit = ${PHP_MEMORY_LIMIT}" > /usr/local/etc/php/conf.d/memory-limit.ini
+    && echo 'memory_limit = ${PHP_MEMORY_LIMIT}' > /usr/local/etc/php/conf.d/memory-limit.ini
 
 RUN adduser -D -h /home/runner -u $RUNNER_UID runner
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Set memory limit
-php -d memory_limit=512M "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Set memory limit
+php -d memory_limit=512M "$@"


### PR DESCRIPTION
Allow to pass in env variable `PHP_MEMORY_LIMIT` with desired memory_limit.
The 128MB is the default (as it has been until now).